### PR TITLE
infinite scroll: replace outdated v-ref directive with "ref" attribute

### DIFF
--- a/source/components/infinite-scroll.md
+++ b/source/components/infinite-scroll.md
@@ -73,7 +73,7 @@ If for some reason you need to control the working state of Infinite Scroll comp
 ``` html
 <quasar-infinite-scroll
   :handler="loadMore"
-  v-ref:infinite-scroll
+  ref="infinite-scroll"
 >
   ...
   <button @click="$refs.infiniteScroll.stop()">

--- a/source/components/infinite-scroll.md
+++ b/source/components/infinite-scroll.md
@@ -73,7 +73,7 @@ If for some reason you need to control the working state of Infinite Scroll comp
 ``` html
 <quasar-infinite-scroll
   :handler="loadMore"
-  ref="infinite-scroll"
+  ref="infiniteScroll"
 >
   ...
   <button @click="$refs.infiniteScroll.stop()">


### PR DESCRIPTION
 v-ref got removed in VueJS 2.0 in favor of the "ref" attribute.