### PR TITLE
Replaced q-search with quasar-search

### DIFF
--- a/source/components/search.md
+++ b/source/components/search.md
@@ -8,22 +8,22 @@ Quasar Search bars lazy evaluate the input with a debounce of 300ms by default.
 ## Basic Usage
 
 ``` html
-<q-search v-model="searchModel"></q-search>
+<quasar-search v-model="searchModel"></quasar-search>
 
 <!-- Disabled state -->
-<q-search
+<quasar-search
   disable
   v-model="searchModel"
-></q-search>
+></quasar-search>
 ```
 
 ### Error State
 Add `has-error` CSS class:
 ``` html
-<q-search
+<quasar-search
   class="has-error"
   v-model="searchModel"
-></q-search>
+></quasar-search>
 ```
 
 ## Vue Properties
@@ -38,12 +38,12 @@ Add `has-error` CSS class:
 
 Example:
 ``` html
-<q-search
+<quasar-search
   v-model="searchModel"
   :debounce="600"
   placeholder="Hotels"
   icon="local_hotel"
-></q-search>
+></quasar-search>
 ```
 
 ## Vue Methods
@@ -55,10 +55,10 @@ Example:
 Use one of the Quasar colors from the Color Palette, like `primary`, `secondary`, `orange`, `teal` as CSS class:
 
 ``` html
-<q-search
+<quasar-search
   class="orange"
   v-model="searchModel"
-></q-search>
+></quasar-search>
 ```
 
 ## Usage with Layout
@@ -67,10 +67,10 @@ If you want to place on Layout header or footer:
 <q-layout>
   ...
   <div slot="header" class="toolbar orange">
-    <q-search
+    <quasar-search
       class="orange"
       v-model="searchModel"
-    ></q-search>
+    ></quasar-search>
   </div>
   ...
 </q-layout>


### PR DESCRIPTION
When trying to use `q-search`, I was getting errors in the console about the component not being registered. However, when I changed the component name to `quasar-search`, it worked as expected.

If this was a change on a specific version, let me know and I will update the docs to specify what to do depending on the version being used so that the docs are clear.