### PR TITLE
docs (layout): custom component as layout slot

### DIFF
--- a/source/components/layout.md
+++ b/source/components/layout.md
@@ -181,6 +181,14 @@ QLayout uses the following Vue slots: `header`, `footer`, `navigation`, `left` a
   </q-layout>
   ```
 
+You can specify your own components as content for these slots too.
+
+  ``` html
+  <q-layout>
+    <my-left-panel slot="left" />
+  </q-layout>
+  ```
+
 You can also use multiple headers, footers and navigation elements. Specify `slot="header"` or `slot="footer"` on multiple elements, when the need arises. Please note though, the order in which you specify these DOM elements / components does matter.
 
 ### The Navigation Slot and Positioning


### PR DESCRIPTION
add hint for possibility to use custom components as layout slots
add example how to use custom components as layout slots

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:
- [x] docs

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
https://gitter.im/quasarframework/Lobby?at=5950c8fe57a6e9f72efd4050