### PR TITLE
fix: Fix the message slot example for infinite scroll

### DIFF
--- a/source/components/infinite-scroll.md
+++ b/source/components/infinite-scroll.md
@@ -13,9 +13,9 @@ When you want to progressively load new content as the user scrolls down your Pa
 
   <!--
     slot="message" for DOM element to display (in this example
-    a spinner) when loading additional content
+    a dots spinner) when loading additional content
   -->
-  <spinner slot="message" name="dots" :size="40"></spinner>
+  <q-spinner-dots slot="message" :size="40"></q-spinner-dots>
 </q-infinite-scroll>
 ```
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

The spinner was not prefixed with `q-` and the `name` property is not longer used.