### PR TITLE
docs(layout): fix broken link to back-to-top [fixes #207]

### DIFF
--- a/source/components/layout.md
+++ b/source/components/layout.md
@@ -280,7 +280,7 @@ These settings are completely up to you to use as you'd like. You could even go 
 ### The "reveal" prop
 You'll notice in playing with the view configuration, if you set the header to "hhh" (all small letters), the header will be set to a static position at the top of the page. This in turn means, the header will move off the screen as the user scrolls down the page. If the user then needs to use the navigation in the header, he/she must scroll completely up to top of the page to get to it and this is bad UX.
 
-One way to help the user, is to add a [back-to-top button](components/back-to-top.html) on the page.
+One way to help the user, is to add a [back-to-top button](/components/back-to-top.html) on the page.
 
 Another way is to use the `reveal` prop.
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: docs

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it) There's already an issue for it #207

**Other information:**
