### PR TITLE
v14 uses <q-icon>, not <i>. Corrected

### DIFF
--- a/source/components/breadcrumb.md
+++ b/source/components/breadcrumb.md
@@ -12,19 +12,19 @@ This component only has CSS code, so you just have to follow the HTML structure 
 <ul class="breadcrumb">
   <li>
     <a>
-      <i>home</i>
+      <q-icon name="home" />
     </a>
   </li>
 
   <li>
     <a>
-      <i>mail</i> Quasar
+      <q-icon name="mail" /> Quasar
     </a>
   </li>
 
   <li>
     <a>
-      <i>cloud</i> Breadcrumb
+      <q-icon name="cloud" /> Breadcrumb
     </a>
   </li>
 </ul>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
