### PR TITLE
Fixing icons in q-side-link example

### DIFF
--- a/source/components/layout-side-links.md
+++ b/source/components/layout-side-links.md
@@ -104,11 +104,13 @@ An even more compelling example with a complex menu on multiple levels.
 ```html
 <q-layout ref="layout" view="hHr LpR Fff">
   <div slot="left">
-    <q-side-link item icon="content_paste" to="/app" exact>
+    <q-side-link item to="/app" exact>
+      <q-item-side icon="content_paste" />
       <q-item-main label="Dashboard" />
     </q-side-link>
 
-    <q-side-link item icon="assignment" to="/app/registrations">
+    <q-side-link item to="/app/registrations">
+      <q-item-side icon="assignment">
       <q-item-main label="Registrations" />
     </q-side-link>
 


### PR DESCRIPTION
The icons only seem to show up when used with q-item-side, and not on q-side-link

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Example documents

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
