### PR TITLE
Making menu button appear when left nav hides

### DIFF
--- a/source/components/layout.md
+++ b/source/components/layout.md
@@ -10,13 +10,14 @@ Below is an example of a Layout, which contains all possible elements:
 - a [QToolbar](/components/toolbar.html) (used for both header and footer, you can specify as many as you want)
 - a navigation with [QTabs](/components/tabs.html)
 - a left side drawer panel (which is shown alongside page content on wide screens)
+- a left side menu button (which is shown only when left side drawer panel is hidden)
 - and a right side drawer panel
 
 ``` html
 <q-layout ref="layout" view="hHr LpR lFf" :right-breakpoint="1100">
   <!-- Header -->
   <q-toolbar slot="header">
-    <q-btn flat @click="$refs.layout.toggleLeft()">
+    <q-btn class="lt-md" flat @click="$refs.layout.toggleLeft()">
       <q-icon name="menu" />
     </q-btn>
     <q-toolbar-title>


### PR DESCRIPTION
Same issue is discussed here: http://forum.quasar-framework.org/topic/536/hide-menu-button-when-drawer-is-fixed-open-desktop-view/9

Fixed using the lt-md class, which seems to be the same breakpoint used for when the drawer hides, so now the menu shows when the drawer hides

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Document example update

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
