### PR TITLE
Adding links to the live demos on the component 'overview' page

### DIFF
--- a/source/components/index.md
+++ b/source/components/index.md
@@ -9,3 +9,7 @@ Quasar Components are written as Web Components, so they embed HTML, CSS and Jav
 > For Vue & Quasar developers (beginners or not), read [Introduction for Beginners](/components/introduction-for-beginners.html) first. It's mandatory in order to understand how you can use Vue properties, methods and so on.
 
 Check out the examples (text and live demos for each platform) to see what each component looks like and to learn how to use each one.
+ 
+[Live Component Demo: Material Theme)](http://quasar-framework.org/quasar-play/android/index.html#/showcase)
+
+[Live Components Demo: iOS Theme)](http://quasar-framework.org/quasar-play/apple/index.html#/showcase)


### PR DESCRIPTION
Adding links to live demos on the component Overview page.  (Personally I'd recommend linking them directly on the left side menu but can't find a way to submit a PR for the menu).  The idea is to make the demo easier to find (if missed on the initial landing page) which should help both new devs and people evaluating the framework.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:  Documentation Update

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
