### PR TITLE
Autocomplete field is for filtering

### DIFF
--- a/source/components/autocomplete.md
+++ b/source/components/autocomplete.md
@@ -76,8 +76,7 @@ When using static data, specify an Object (notice that it uses some properties f
 ``` js
 // static-data
 [
-  // Property name from array of objects below
-  // that will fill input box when suggestion is selected
+  // Property name that will be used by filter() to filter the array of objects below.
   field: 'value',
 
   list: [


### PR DESCRIPTION
The static-data field is used for filtering.  Is does not fill the input box when selected.  The select item.value is used to fill the input box when selected.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Documentation fix

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
