### PR TITLE
Add ES6 arrow function to initial Dialog example

### DIFF
--- a/source/components/dialog.md
+++ b/source/components/dialog.md
@@ -27,8 +27,10 @@ Dialog.create({
     'Cancel',
     {
       label: 'Empty Trash Bin',
-      handler () {
+      handler: () => {
         // empty the trash bin, yo
+        // Note the ES6 arrow function in the handler definition.
+        // See the `Tip on using "this" in the handler` below for an explanation
       }
     }
   ]


### PR DESCRIPTION
The initial example, in the doc, of how to use a Dialog does not include an ES6 arrow in the handler.  This inevitably will result in people cutting and pasting the code and ending up with 'this' scope errors in the handler.   I changed the example to include the ES6 arrow by default, as well added a comment in the handler code itself so people 'cut and paste' that there is an explanation if needed.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
