### PR TITLE
Show how to support Vuex and browsers requiring Promise polyfill

### DIFF
--- a/source/guide/browser-support.md
+++ b/source/guide/browser-support.md
@@ -22,3 +22,10 @@ Adding support for IE11/Edge requires you to check `src/main.js` in your project
 
 Due to the fact that it adds about ~10KB (mainly due to Promise polyfill) to the bundle size (we care about bundle size!) and there are cases where you don't need it (like Cordova apps for iOS or Android), this is totally optional. Uncomment those two lines and that's everything you need to do.
 
+# Vuex and Promise polyfill
+
+If you are using Vuex in your project and you need to support browsers that require a Promise polyfill, you should additionally add the following line to `src/main.js` before importing your Vuex store:
+
+``` js
+import 'es6-promise/auto'
+```


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Documentation

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
I found an issue when using Vuex and needing to support a browser that requires a Promise polyfill (phantomjs for e2e testing):

`Error: [vuex] vuex requires a Promise polyfill in this browser.`

I uncommented the two `require` statements to support IE, but I think this suffers from a hoisting issue mentioned here: https://github.com/vuejs-templates/webpack/issues/474#issuecomment-278748816

I'm not sure if this is the best place to mention this, or if it would make more sense in the troubleshooting page of the doco... or if you have a better way of handling this?