### PR TITLE
This example fails linting out of the box

### DIFF
--- a/source/components/integrating-layout-with-router.md
+++ b/source/components/integrating-layout-with-router.md
@@ -19,7 +19,7 @@ Vue.use(VueRouter)
   to benefit from HMR
  */
 function load (component) {
-  return () => System.import(`components/${component}.vue`)
+  return () => System.import(`components/${component}.vue`) // eslint-disable-line no-undef
 }
 
 const routes = [


### PR DESCRIPTION
System isn't imported so linting fails.  I don't even know where it is coming from, but disabling the lint for the line makes the example work.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
