### PR TITLE
Added information to not use margin but padding

### DIFF
--- a/source/components/layout.md
+++ b/source/components/layout.md
@@ -165,6 +165,9 @@ You can also use [QScrollArea](/components/scroll-area.html) for the left or rig
 
 ## Tips to Understanding QLayout
 
+> **Using margin CSS will break the layout**
+> QLayout depends on taking up the whole screen and so QPageContainer, QLayoutHeader, QLayoutFooter and QLayoutDrawer positions are managed by it (through `view` prop). You **cannot** use *CSS margins* as a style neither on QLayout itself nor on any of the components mentioned above. However use can safely use *CSS padding*.
+
 ### Routing
 If your layout uses Vue Router sub-routes (recommended), then it makes sense to use Vue's `<router-view />` component, which is just a placeholder where sub-routes are injected.
 
@@ -234,17 +237,3 @@ These settings are completely up to you to use as you'd like. You could even go 
 | `@resize` | Event emitted on window resize. |
 | `@scroll` | Event emitted on page scroll. |
 | `@scrollHeight` | Event emitted on page scroll height change. |
-
-# Caveats
-
-## Using *margin* will break the layout
-
-QLayout depends on taking the whole screen. So you **cannot** use *margins* as a style neither on QLayout itself nor on 
-any of the slots (e.g. *header*, *footer* , ...). Instead, use *padding*.
-
-```
-   <!-- Use padding instead of margin! -->
-   <q-layout :header-style="{'padding-top': '50px'}>
-      <div slot="header"></div>
-   </q-layout>
-```

--- a/source/components/layout.md
+++ b/source/components/layout.md
@@ -234,3 +234,17 @@ These settings are completely up to you to use as you'd like. You could even go 
 | `@resize` | Event emitted on window resize. |
 | `@scroll` | Event emitted on page scroll. |
 | `@scrollHeight` | Event emitted on page scroll height change. |
+
+# Caveats
+
+## Using *margin* will break the layout
+
+QLayout depends on taking the whole screen. So you **cannot** use *margins* as a style neither on QLayout itself nor on 
+any of the slots (e.g. *header*, *footer* , ...). Instead, use *padding*.
+
+```
+   <!-- Use padding instead of margin! -->
+   <q-layout :header-style="{'padding-top': '50px'}>
+      <div slot="header"></div>
+   </q-layout>
+```


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [X] Other, please describe: documentation

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all major browsers (it's just documentation)

**Other information:**
Currently, it is not clear that you cannot use margin as a style on QLayout or on its slots. I added this information at the end under a new *Caveats* section.