### PR TITLE
Add Warning re: running dev server in win7 and consume in ie11

### DIFF
--- a/source/guide/app-supporting-ie.md
+++ b/source/guide/app-supporting-ie.md
@@ -19,5 +19,5 @@ That's it. This will inject the Promise polyfill, along with some other smaller 
 > Quasar CLI is smart enough to include the IE pollyfills only if it is really needed. An Electron app for example doesn't need it and as a result, even if you leave `supportIE` set to "true" in quasar.conf.js it won't be bundled.
 
 > **WARNING**
-> Running dev server on a Windows 7 machine and consuming the output in IE11 will result in a eror (ansi-strip package related used by webpack-dev-server)
-> This is only an issue during development, and if you run the dev server in a Linux, MAC, or Windows 10 machine you can consume it safely in IE11
+> Running dev server on a Windows 7 machine and consuming the output in IE11 will result in an error (ansi-strip package related used by webpack-dev-server).
+> This is only an issue during development, and if you run the dev server on a Linux, MAC, or Windows 10 machine you can consume it safely in IE11.

--- a/source/guide/app-supporting-ie.md
+++ b/source/guide/app-supporting-ie.md
@@ -17,3 +17,7 @@ That's it. This will inject the Promise polyfill, along with some other smaller 
 
 > **NOTE**
 > Quasar CLI is smart enough to include the IE pollyfills only if it is really needed. An Electron app for example doesn't need it and as a result, even if you leave `supportIE` set to "true" in quasar.conf.js it won't be bundled.
+
+> **WARNING**
+> Running dev server on a Windows 7 machine and consuming the output in IE11 will result in a eror (ansi-strip package related used by webpack-dev-server)
+> This is only an issue during development, and if you run the dev server in a Linux, MAC, or Windows 10 machine you can consume it safely in IE11


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
