### PR TITLE
Fix link to 'app-routing' page as the currently linked page is dead

### DIFF
--- a/source/guide/app-adding-pages-and-layouts.md
+++ b/source/guide/app-adding-pages-and-layouts.md
@@ -2,7 +2,7 @@ title: Adding Pages and Layouts
 ---
 Your Pages (`/src/pages`) and Layouts (`/src/layouts`) are injected into your website/app (and also managed) through Vue Router in `/src/router/routes.js`. Each Page and Layout needs to be referenced there.
 
-You may want to read [Routing](/guide/routing.html) first and also understand [Lazy Loading / Code Splitting](/guide/app-lazy-loading---code-splitting.html).
+You may want to read [Routing](/guide/app-routing.html) first and also understand [Lazy Loading / Code Splitting](/guide/app-lazy-loading---code-splitting.html).
 
 Example of `routes.js`:
 ```js


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
