### PR TITLE
improve for new user readability

### DIFF
--- a/source/components/internationalization.md
+++ b/source/components/internationalization.md
@@ -71,10 +71,10 @@ There's also a method to determine user locale which is supplied by Quasar out o
 ```js
 // outside of a Vue file
 import Quasar from 'quasar'
-(String) Quasar.i18n.getLocale()
+Quasar.i18n.getLocale() // returns a string
 
 // inside of a Vue file
-(String) this.$q.i18n.getLocale()
+this.$q.i18n.getLocale() // returns a string
 ```
 
 ## Handling Quasar UMD


### PR DESCRIPTION
New users might try to directly use:
```js
let locale = (String) Quasar.i18n.getLocale()
```
So I believe (especially with JS syntax highlight) that the `(String)` written in front of the function is confusing.
