### PR TITLE
I add an example of how to use the device plugin to demonstrate how g…

### DIFF
--- a/source/components/internationalization.md
+++ b/source/components/internationalization.md
@@ -2,7 +2,7 @@ title: Internationalization (I18n)
 ---
 Internationalization is a design process that ensures a product (a website or application) can be adapted to various languages and regions without requiring engineering changes to the source code. Think of internationalization as readiness for localization.
 
-Recommended package for handling website/app is [vue-i18n](https://github.com/kazupon/vue-i18n).
+Recommended package for handling website/app is [vue-i18n](https://github.com/kazupon/vue-i18n). It should be noted that what is described below is the internationalization of quasar-framework components. If you need to internationalize your own components, read the documentation indicated above and configure the project by editing the files located in `<project>/src/i18n`
 
 However, handling I18n in app-space is not enough. Quasar components have their own labels too. One option is to configure labels through label properties on each instance of Quasar components like QTable or QDatetime. This takes time and adds unnecessary complexity to your website/app. Instead, use the Quasar I18n (applies to Quasar components only!) system.
 

--- a/source/guide/cordova-plugins.md
+++ b/source/guide/cordova-plugins.md
@@ -19,7 +19,7 @@ A few examples of such plugins:
 * Statusbar
 
 ## Deviceready Event
-You'll notice that some Cordova plugins are usable only after the `deviceready` event has been triggered. We don't need to worry about it too much. Quasar listens to this event and takes care of our root Vue component to be mounted **after** this event has been triggered.
+You'll notice that some Cordova plugins are usable only after the `deviceready` event has been triggered. We don't need to worry about it too much. Quasar listens to this event and takes care of our root Vue component to be mounted **after** this event has been triggered. But if you need some plugin's own variable and that is initialized after `deviceready` you can follow the example of using the plugin device below
 
 ### Caveat
 Let's take a vue file for example:
@@ -143,6 +143,64 @@ export default {
         }
       )
     }
+  }
+}
+</script>
+```
+
+### Example: Device
+First step is to read the documentation of the Cordova plugin that we want to use. We look at [Cordova Plugins list](https://cordova.apache.org/docs/en/latest/#plugin-apis) and click on [Device doc page](https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-device/index.html).
+
+This plugin initializes a global variable called `device` which describes the device's hardware and software. As Quasar is the one who captures this event, you need modify the .eslintrc.js file, leaving the property globals in this way:
+
+```
+globals: {
+    'ga': true, // Google Analytics
+    'cordova': true,
+    'device': true,
+    '__statics': true
+  }
+```
+
+We read the instructions on how to install this plugin. It's always a Cordova command. **So we "cd" into `/src-cordova`** (which is a Cordova generated folder) **and issue the install command form there**:
+```bash
+# from /src-cordova:
+$ cordova plugin add cordova-plugin-device
+```
+
+Now let's put this plugin to some good use. If you need the information of your device when starting the application, you will have to capture the created event. In one of your Quasar project's pages/layouts/components Vue file, we write:
+
+```html
+// some Vue file
+// remember this is simply an example;
+// only look at how we use the API described in the plugin's page;
+// the rest of things here are of no importance
+
+<template>
+  <div>
+    <q-page class="flex flex-center">
+      <div>IMEI {{IMEI}}</div>
+    </q-btn>
+  </q-page>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      IMEI: ''
+    }
+  },
+  created () {
+    if (typeof device === 'undefined') {
+      this.IMEI = 'Run this on one mobile'
+    } else {
+      this.IMEI = device.uuid
+    }
+  },
+  methods: {
+    
   }
 }
 </script>

--- a/source/guide/cordova-plugins.md
+++ b/source/guide/cordova-plugins.md
@@ -149,20 +149,11 @@ export default {
 ```
 
 ### Example: Device
-First step is to read the documentation of the Cordova plugin that we want to use. We look at [Cordova Plugins list](https://cordova.apache.org/docs/en/latest/#plugin-apis) and click on [Device doc page](https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-device/index.html).
+First step is to read the documentation of the Cordova plugin that we want to use. Look at the [Cordova Plugins list](https://cordova.apache.org/docs/en/latest/#plugin-apis) and click on [Device doc page](https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-device/index.html).
 
-This plugin initializes a global variable called `device` which describes the device's hardware and software. As Quasar is the one who captures this event, you need modify the .eslintrc.js file, leaving the property globals in this way:
+This plugin initializes a global variable called `device` which describes the device's hardware and software. So it can be accessed with `window.device`.
 
-```
-globals: {
-    'ga': true, // Google Analytics
-    'cordova': true,
-    'device': true,
-    '__statics': true
-  }
-```
-
-We read the instructions on how to install this plugin. It's always a Cordova command. **So we "cd" into `/src-cordova`** (which is a Cordova generated folder) **and issue the install command form there**:
+Read the instructions on how to install this plugin on its cordova doc page. It's always a Cordova command. **So we "cd" into `/src-cordova`** (which is a Cordova generated folder) and **issue the install command from there**:
 ```bash
 # from /src-cordova:
 $ cordova plugin add cordova-plugin-device
@@ -189,18 +180,10 @@ Now let's put this plugin to some good use. If you need the information of your 
 export default {
   data () {
     return {
-      IMEI: ''
+      IMEI: window.device === void 0
+        ? 'Run this on a mobile/tablet device'
+        : window.device
     }
-  },
-  created () {
-    if (typeof device === 'undefined') {
-      this.IMEI = 'Run this on one mobile'
-    } else {
-      this.IMEI = device.uuid
-    }
-  },
-  methods: {
-    
   }
 }
 </script>


### PR DESCRIPTION
1º I add an example of how to use the device plugin to demonstrate how global variables are handled in the initialization of the project. +INFO: http://forum.quasar-framework.org/topic/2077/documentation-review

2º I indicate the path of the vue-i18n plugin with which the proprietary components are internationalized

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature: Add one example on documentation page
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

- I add an example of how to use the device plugin to demonstrate how global variables are handled in the initialization of the project. +INFO: http://forum.quasar-framework.org/topic/2077/documentation-review

- I try to be more explicit on the internacionalization documentation process