### PR TITLE
fixed data-table example misspelling

### DIFF
--- a/source/components/datatable.md
+++ b/source/components/datatable.md
@@ -187,7 +187,7 @@ export default {
 <template>
   <q-table
     :filter="terms"
-    :filter-method="myFiler"
+    :filter-method="myFilter"
     ...
 </template>
 


### PR DESCRIPTION
go to source/components/datatable.md Line 190

When trying to use the example of this component, i encountered an error. The results of this error was a misspelling of myFilter. It was initially myFiler
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
