### PR TITLE
Document stopLoading parameter on the done callback

### DIFF
--- a/source/components/infinite-scroll.md
+++ b/source/components/infinite-scroll.md
@@ -56,7 +56,8 @@ loadMore: function(index, done) {
   // index - called for nth time
   // done - Function to call when you made all necessary updates.
   //        DO NOT forget to call it otherwise your loading message
-  //        will continue to be displayed
+  //        will continue to be displayed. Has optional boolean
+  //        parameter that invokes stop() when true
 
   // make some Ajax call then call done()
 }


### PR DESCRIPTION
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other: missing documentation

Added a note about the optional `stopLoading` parameter on the `done` callback of the `handler` function for `QInfiniteScroll`, which was not previously documented.