### PR TITLE
clarification on icon-right

### DIFF
--- a/source/components/dropdown-button.md
+++ b/source/components/dropdown-button.md
@@ -48,7 +48,7 @@ All props except `split` are shared with [QBtn](/components/button.html).
 | ---          | ---     | --- |
 | `split`      | Boolean | Use a split QBtnDropdown |
 | `icon`       | String  | Name of the icon to use. |
-| `icon-right` | String  | Name of the icon to place on right side of button. |
+| `icon-right` | String  | Name of the icon to place on right side of button. (only usable with `split` set to `true`) |
 | `loading`    | Boolean | Display a spinner, if true. Can be optionally used along `v-model`. Check [Button with Progress](#Button-with-Progress) section. |
 | `percentage` | Number | Optional property for displaying a determinate progress. Use along `loading`. |
 | `dark-percentage` | Boolean | Optional property for displaying a determinate progress on a light button color. Use along `loading` and `percentage`. |


### PR DESCRIPTION
from the discord conversation. Some ppl were confused about `icon-right`
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Provided documentation update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
