### PR TITLE
Wording fix in SSR Documentation Guide

### DIFF
--- a/source/guide/pwa-configuring-pwa.md
+++ b/source/guide/pwa-configuring-pwa.md
@@ -1,6 +1,6 @@
 title: Configuring PWA
 ---
-We'll be using Quasar CLI to develop and build a PWA. The difference between building a SPA, Mobile App, Electron App or a PWA is simply determined by the "mode" parameter in "quasar dev" and "quasar build" commands.
+We'll be using Quasar CLI to develop and build a PWA. The difference between building a SPA, Mobile App, Electron App, PWA or SSR is simply determined by the "mode" parameter in "quasar dev" and "quasar build" commands.
 
 ## Installation
 In order to build a PWA, we first need to add the PWA mode to our Quasar project:

--- a/source/guide/ssr-configuring-ssr.md
+++ b/source/guide/ssr-configuring-ssr.md
@@ -4,7 +4,7 @@ title: Configuring SSR
 We’ll be using Quasar CLI to develop and build a SSR website. The difference between building a SPA, Mobile App, Electron App, PWA or SSR is simply determined by the “mode” parameter in “quasar dev” and “quasar build” commands.
 
 ## Installation
-In order to build a PWA, we first need to add the PWA mode to our Quasar project:
+In order to build a SSR website, we first need to add the SSR mode to our Quasar project:
 ```bash
 $ quasar mode -a ssr
 ```


### PR DESCRIPTION
ssr-configuring-ssr.md -> 'PWA' should be 'SSR'
pwa-configuring-pwa.md -> Adding 'SSR' to have the same description as 'ssr-configuring-ssr.md' file