### PR TITLE
Upgrade Quasar Link on v0.14

### DIFF
--- a/themes/quasar/layout/index.ejs
+++ b/themes/quasar/layout/index.ejs
@@ -10,6 +10,15 @@
         Build responsive websites, PWAs, hybrid mobile Apps (that look native!) and Electron apps,
         all simultaneously using same codebase, powered with Vue.
         <br><br>
+        <a
+          href="https://quasar-framework.org"
+          target="_blank"
+          class="beta-link"
+        >
+          <i class="fa fa-hand-peace-o"></i>
+          Please upgrade to latest version
+        </a>
+        <br><br>
         <i class="fa fa-hand-o-right"></i>
         Demo:
         [ <a

--- a/themes/quasar/layout/partials/sidebar.ejs
+++ b/themes/quasar/layout/partials/sidebar.ejs
@@ -16,6 +16,15 @@
       </a>
     </div>
     <br><br>
+    <a
+      href="https://quasar-framework.org"
+      target="_blank"
+      class="sidebar-link current"
+    >
+      <i class="fa fa-hand-peace-o"></i>
+      Please upgrade to latest Quasar
+    </a>
+    <br><br>
     <div>
       Proudly sponsored by:
       <a href="http://truelogic.com/" target="_blank">


### PR DESCRIPTION
The "Upgrade Quasar" link was missing on this version