### PR TITLE
Added warning for breakpoint customization

### DIFF
--- a/source/components/flex-css.md
+++ b/source/components/flex-css.md
@@ -226,6 +226,9 @@ $sizes = {
 }
 ```
 
+> **IMPORTANT**
+> When customizing breakpoints, the smallest one must _always_ be zero.
+
 ## Using Gutters
 There are 5 types of gutter, depending on the amount of space that you want between your elements:
 


### PR DESCRIPTION
If the smallest breakpoint  is greater than 0 it causes issues with `.col`

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Provided documentation update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
