### PR TITLE
remove the word JavaScript from the PWA cache reference

### DIFF
--- a/source/guide/pwa-introduction.md
+++ b/source/guide/pwa-introduction.md
@@ -26,7 +26,7 @@ More information on the Manifest file can be read by accessing:
 https://developer.mozilla.org/en-US/docs/Web/Manifest
 
 ## Service Worker
-The Service worker provides a programmatic way to cache app resources. Be it files or JSON data from a HTTPS request. The programmatic API allows developers to decide how to handle caching and provides a much more flexible experience than other options.
+The Service worker provides a programmatic way to cache app resources (files). The programmatic API allows developers to decide how to handle caching and provides a much more flexible experience than other options.
 
 More information on the Service Worker API can be read by accessing:
 https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API

--- a/source/guide/pwa-introduction.md
+++ b/source/guide/pwa-introduction.md
@@ -26,7 +26,7 @@ More information on the Manifest file can be read by accessing:
 https://developer.mozilla.org/en-US/docs/Web/Manifest
 
 ## Service Worker
-The Service worker provides a programmatic way to cache app resources. Be it JavaScript files or JSON data from a HTTPS request. The programmatic API allows developers to decide how to handle caching and provides a much more flexible experience than other options.
+The Service worker provides a programmatic way to cache app resources. Be it files or JSON data from a HTTPS request. The programmatic API allows developers to decide how to handle caching and provides a much more flexible experience than other options.
 
 More information on the Service Worker API can be read by accessing:
 https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API


### PR DESCRIPTION
PWA cache can store images, css, PDF's, or just about any file type so to say it's just JS is not correct.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Provided documentation update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
