### PR TITLE
Add a Example of advanced select object

### DIFF
--- a/source/components/select.md
+++ b/source/components/select.md
@@ -70,35 +70,35 @@ export default {
         }
       ],
       selectAdvancedListOptions: [
-          {
-            label: 'Google',
-            icon: 'search',
-            value: 'goog'
-          },
-          {
-            label: 'Facebook',
-            inset: true,
-            sublabel: 'Enables communication',
-            value: 'fb'
-          },
-          {
-            label: 'Oracle',
-            sublabel: 'Some Java for today?',
+        {
+          label: 'Google',
+          icon: 'search',
+          value: 'goog'
+        },
+        {
+          label: 'Facebook',
+          inset: true,
+          sublabel: 'Enables communication',
+          value: 'fb'
+        },
+        {
+          label: 'Oracle',
+          sublabel: 'Some Java for today?',
 
-            icon: 'mail',
-            leftColor: 'secondary', // color for left side, whatever it is (icon, letter, ...)
+          icon: 'mail',
+          leftColor: 'secondary', // color for left side, whatever it is (icon, letter, ...)
 
-            rightIcon: 'alarm',
-            rightColor: 'negative', // color for right side, whatever it is (icon, letter, ...)
+          rightIcon: 'alarm',
+          rightColor: 'negative', // color for right side, whatever it is (icon, letter, ...)
 
-            value: 'ora'
-          },
-          {
-            label: 'Apple Inc.',
-            inset: true,
-            stamp: '10 min',
-            value: 'appl'
-          }
+          value: 'ora'
+        },
+        {
+          label: 'Apple Inc.',
+          inset: true,
+          stamp: '10 min',
+          value: 'appl'
+        }
       ]
     }
   }

--- a/source/components/select.md
+++ b/source/components/select.md
@@ -47,6 +47,11 @@ framework: {
       :options="selectOptions"
       @change="inputChange"
     />
+    <!-- Advanced Select List Object Example-->
+    <q-select
+      v-model="select"
+      :options="selectAdvancedListOptions"
+		/>
   </div>
 </template>
 
@@ -63,6 +68,37 @@ export default {
           label: 'Facebook',
           value: 'fb'
         }
+      ],
+      selectAdvancedListOptions: [
+          {
+            label: 'Google',
+            icon: 'search',
+            value: 'goog'
+          },
+          {
+            label: 'Facebook',
+            inset: true,
+            sublabel: 'Enables communication',
+            value: 'fb'
+          },
+          {
+            label: 'Oracle',
+            sublabel: 'Some Java for today?',
+
+            icon: 'mail',
+            leftColor: 'secondary', // color for left side, whatever it is (icon, letter, ...)
+
+            rightIcon: 'alarm',
+            rightColor: 'negative', // color for right side, whatever it is (icon, letter, ...)
+
+            value: 'ora'
+          },
+          {
+            label: 'Apple Inc.',
+            inset: true,
+            stamp: '10 min',
+            value: 'appl'
+          }
       ]
     }
   }

--- a/source/components/select.md
+++ b/source/components/select.md
@@ -51,7 +51,7 @@ framework: {
     <q-select
       v-model="select"
       :options="selectAdvancedListOptions"
-		/>
+    />
   </div>
 </template>
 


### PR DESCRIPTION
I was thinking was not possible to add a sub-labels or other advanced things on q-select, due the lack of exemple on the documentation. Asking on the discord community other users didn't know also, so I would like to propose an update on documentation. Add a exemple with the "selectListOptions" array we have on the actual documentation.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Provided documentation update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
