### PR TITLE
mention that upload factory should resolve with the file

### DIFF
--- a/source/components/uploader.md
+++ b/source/components/uploader.md
@@ -27,7 +27,7 @@ framework: {
 | `name` | String | Name of the file, if it should be different than the file's name. |
 | `headers` | Object | Specify what headers need to be added to the XHR request |
 | `url-factory` | Function | Function (with `file` object received as parameter) which returns a Promise that resolves to a URL. |
-| `upload-factory` | Function | (v0.17+) Function defining a custom upload method which returns a Promise. Check section below. |
+| `upload-factory` | Function | (v0.17+) Function defining a custom upload method which returns a Promise that resolves with a file. Check section below. |
 | `no-content-type` | Boolean | (v0.17+) Avoid setting Content-Type header when uploading. |
 | `with-credentials` | Boolean | (v0.17+) Sets `xhr.withCredentials` to `true` (doesn't apply when using `upload-factory`). |
 | `method` | String | HTTP method to use (POST/PUT). Defaults to POST. |


### PR DESCRIPTION
It wasn't obvious to me that an upload factory should resolve with the file.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Provided documentation update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
