### PR TITLE
update progress takes a number between 0 and 1, not a percentage

### DIFF
--- a/source/components/uploader.md
+++ b/source/components/uploader.md
@@ -83,8 +83,8 @@ export default {
     uploadFactory (file, updateProgress) {
       // "file" is an Object containing file's props, including content
 
-      // for updating progress (as 0-100 number), we need to call:
-      // updateProgress (percentage)
+      // for updating progress (as 0-1 number), we need to call:
+      // updateProgress (progress)
 
       // we need to return a Promise
       // (resolves when upload is done, rejects when there's an error)

--- a/source/components/uploader.md
+++ b/source/components/uploader.md
@@ -83,7 +83,7 @@ export default {
     uploadFactory (file, updateProgress) {
       // "file" is an Object containing file's props, including content
 
-      // for updating progress (as 0-1 number), we need to call:
+      // for updating progress (as 0-1 floating number), we need to call:
       // updateProgress (progress)
 
       // we need to return a Promise


### PR DESCRIPTION
I noticed that the updateProgress() function takes a number/float between 0 and 1, not a percentage.

Not sure if this is a typo in the docs, or a bug in the uploader component.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Provided documentation update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
