### PR TITLE
Add newline to for readability on small screens

### DIFF
--- a/source/components/select.md
+++ b/source/components/select.md
@@ -122,7 +122,7 @@ Supports `v-model` which should be the String for single selection and Array for
 | `chips-color` | String | Override default children chips text color. |
 | `chips-bg-color` | String | Override default children chips background color. |
 | `readonly` | Boolean | If set to `true`, select is readonly and the user cannot change model. |
-| `filter` | Boolean/Function(terms,obj) | If set to `true` or supplying a filter function, the selections will offer an input to filter the selection options. |
+| `filter` | Boolean /<br>Function(terms, obj) | If set to `true` or supplying a filter function, the selections will offer an input to filter the selection options. |
 | `autofocus-filter` | Boolean | Auto-focus on the filter input field (if available) when opening selection. |
 | `filter-placeholder` | String | A text to show in the filter input field. Default is "Filter". |
 | `separator` | Boolean | If set to `true`, the selection options will be separated by a line. |


### PR DESCRIPTION
See screenshot:
<img width="810" alt="2018-09-07 12 27 29" src="https://user-images.githubusercontent.com/3253920/45196935-a3a46300-b299-11e8-9686-bb3fd4d4122d.png">


To prevent this a new line was added after `Boolean /`