### PR TITLE
feat(QTimelineEntry): Allow titles slots for Timeline Entries

### DIFF
--- a/source/components/timeline.md
+++ b/source/components/timeline.md
@@ -35,6 +35,8 @@ framework: {
 </q-timeline>
 ```
 ## Customize Entries Titles via slots
+*Quasar v0.17.18+*
+
 ```html
 <q-timeline responsive color="secondary">
   <q-timeline-entry

--- a/source/components/timeline.md
+++ b/source/components/timeline.md
@@ -34,6 +34,36 @@ framework: {
   </q-timeline-entry>
 </q-timeline>
 ```
+## Customize Entries Titles via slots
+```html
+<q-timeline responsive color="secondary">
+  <q-timeline-entry
+    subtitle="April 22, 1991"
+    side="left"
+  >
+    <div>
+      Lorem ipsum dolor sit amet.
+    </div>
+    <!--
+      Use the class q-timeline-title to stick to original styling when using slots
+    -->
+    <h3 slot="title" class="q-timeline-title">
+      <q-icon name="account_balance" />
+      <span>Event</span>
+      <em>Title</em>
+    </h3>
+    <!--
+      Use the class q-timeline-subtitle to stick to original styling when using slots
+    -->
+    <h5 slot="subtitle" class="q-timeline-subtitle">
+      <q-icon name="warning" />
+      <span>April 22,</span>
+      <em>1991</em>
+    </h5>
+  </q-timeline-entry>
+</q-timeline>
+```
+
 
 ## QTimeline (Parent) Vue Properties
 | Vue Property | Type    | Description                            |


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Provided documentation update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
As I stated in https://github.com/quasarframework/quasar/pull/2736:
I would like to allow to add icons, buttons and other elements to the title and subtitle of a Timeline Entry. In order to allow any kind of customization and retain current behaviour as default. I came with a feature which allows to indicate those via slots.
Thank U