### PR TITLE
Clarify formatDate i18n usage

### DIFF
--- a/source/components/date-utils.md
+++ b/source/components/date-utils.md
@@ -32,7 +32,7 @@ let timeStamp = Date.now()
 let formattedString = date.formatDate(timeStamp, 'YYYY-MM-DDTHH:mm:ss.SSSZ')
 ```
 
-For i18n, you can use a third parameter:
+For `$q.i18n` (Quasar's built in localization), locale will be set automatically based on the global quasar `locale`. For custom i18n, you can use a third parameter:
 ```js
 let formattedString = date.formatDate(timesStamp, 'MMMM - dddd', {
   dayNames: ['Duminica', 'Luni', /* and all the rest of days - remember starting with Sunday */],


### PR DESCRIPTION
Update to add clarity to how formatDate handles i18n. The third parameter only needs to be used when using your own custom i18n instance. Quasar will handle it's own internal one and set the locale when it changes.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ x] Provided documentation update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
