### PR TITLE
Document 'add(files)' and 'pick()' methods.

### DIFF
--- a/source/components/uploader.md
+++ b/source/components/uploader.md
@@ -164,6 +164,8 @@ Examples:
 | Vue Method | Description |
 | --- | --- |
 | `upload()` | Start file(s) upload. |
+| `pick()` | Trigger file pick (same as clicking the plus button on the uploader). Must be called as a direct consequence of user interaction (eg. in a click handler), due to browsers security policy. |
+| `add(files)` | Add array of files. |
 | `abort()` | Abort uploading file(s). |
 | `reset()` | Reset uploader state. |
 


### PR DESCRIPTION
Seems like those methods are intended to be public. Check the wording please.