### PR TITLE
Fix bug in `Scrolling to an element` snippet

### DIFF
--- a/source/components/scrolling-utils.md
+++ b/source/components/scrolling-utils.md
@@ -34,7 +34,7 @@ const { getScrollTarget, setScrollPosition } = scroll
 // takes an element object
 function scrollToElement (el) {
   let target = getScrollTarget(el)
-  let offset = el.offsetTop - el.scrollHeight
+  let offset = el.offsetTop
   let duration = 1000
   setScrollPosition(target, offset, duration)
 }


### PR DESCRIPTION
The function doesn't work properly when doing `let offset = el.offsetTop - el.scrollHeight`
Because when the scrollHeight of the element you want to scroll to is almost the size of the entire page, the offset you will be left with will be very small or below 0. That means that `setScrollPosition` will not respond properly, and only go down a few pixels.

The solution is just to go to the `el.offsetTop` instead of the `el.offsetTop - el.scrollHeight`
