### PR TITLE
adjust vue-cli package target to get v3.x

### DIFF
--- a/source/guide/index.md
+++ b/source/guide/index.md
@@ -68,9 +68,9 @@ First, we will need to install Quasar CLI. Make sure you have Node >=8 and NPM >
 ```bash
 # make sure you have vue-cli globally installed
 # -- the init procedure to scaffold the project files uses vue-cli init command
-$ yarn global add vue-cli # or @vue/cli @vue/cli-init
+$ yarn global add @vue/cli # or @vue/cli-init   note that using vue-cli will install vue-cli 2.x
 # or:
-$ npm install -g vue-cli # or @vue/cli @vue/cli-init
+$ npm install -g @vue/cli # or @vue/cli-init    note using vue-cli alone will install vue-cli 2.x
 
 # Node.js >= 8.9.0 is required.
 $ yarn global add quasar-cli


### PR DESCRIPTION
npm install vue-cli, as suggested, installs vue-cli 2.x at present.  These docs then suggest you need 3.x.  I've adjusted the targets in the install commands to get 3.x instead.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Provided documentation update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
