### PR TITLE
Added a missed ',' after the methods property

### DIFF
--- a/source/guide/cordova-plugins.md
+++ b/source/guide/cordova-plugins.md
@@ -81,7 +81,7 @@ export default {
     updateBatteryStatus (status) {
       this.batteryStatus = `Level: ${status.level}, plugged: ${status.isPlugged}`
     }
-  }
+  },
   created () {
     // we register the event like on plugin's doc page
     window.addEventListener('batterystatus', this.updateBatteryStatus, false)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Provided documentation update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ x] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
